### PR TITLE
Change About page URL to /about

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -8,7 +8,7 @@ menu:
 - {name: 'Productivity', path: 'menu', url: 'productivity'}
 - {name: 'Growth', path: 'menu', url: 'growth'}
 - {name: 'Chill', path: 'menu', url: 'chill'}
-- {name: 'About', path: 'menu', url: 'about'}
+- {name: 'About', path: '', url: 'about'}
 
 
 

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,7 +1,7 @@
 <div class="menu">
   <nav class="menu-content">
     {% for item in site.data.settings.menu %}
-      <a href="{{ site.github.url }}/{{ item.path }}/{{ item.url }}">{{ item.name }}</a>
+      {% if item.path != '' %}<a href="{{ site.github.url }}/{{ item.path }}/{{ item.url }}">{{ item.name }}</a>{% else %}<a href="{{ site.github.url }}/{{ item.url }}">{{ item.name }}</a>{% endif %}
     {% endfor %}
   </nav>
   <nav class="social-icons">

--- a/menu/about.md
+++ b/menu/about.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: About
+permalink: /about
 ---
 
 ![Marko](../assets/img/msrsan.jpg){:class="img-responsive"} 


### PR DESCRIPTION
Change About page URL from /menu/about to /about. Adds permalink to front matter, updates menu settings entry, and tweaks menu template to handle empty path.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ffSU8eZbDUfbTCZakxtv9)_